### PR TITLE
devAvail property not availabe for RSP hardware version 1 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.6)
+project(examples)
+
+set(CMAKE_CXX_STANDARD 11)
+
+set(SOURCE_FILES
+        play_sdr.c)
+
+add_executable(play_sdr ${SOURCE_FILES})
+target_link_libraries (play_sdr pthread m mirsdrapi-rsp)

--- a/play_sdr.c
+++ b/play_sdr.c
@@ -359,18 +359,16 @@ int main(int argc, char **argv)
     mir_sdr_GetDevices(&devices[0], &numDevs, 4);
 
     for(i = 0; i < numDevs; i++) {
-        if(devices[i].devAvail == 1) {
+        if(devices[i].hwVer == 2 && devices[i].devAvail == 1) {
+            devAvail++;
+        }
+        else{ // devAvail not available on RSP hardware Version 1
             devAvail++;
         }
     }
 
     if (devAvail == 0) {
         fprintf(stderr, "ERROR: No RSP devices available.\n");
-        exit(1);
-    }
-
-    if (devices[device].devAvail != 1) {
-        fprintf(stderr, "ERROR: RSP selected (%d) is not available.\n", (device + 1));
         exit(1);
     }
 

--- a/play_sdr.c
+++ b/play_sdr.c
@@ -82,27 +82,27 @@ double atofs(char *s)
 
 void usage(void)
 {
-	fprintf(stderr,
-		"play_sdr, an I/Q recorder for SDRplay RSP receivers\n\n"
-		"Usage:\t[-f frequency_to_tune_to [Hz]\n"
-        "\t[-d RSP device to use (default: 1, first found)]\n"
-		"\t[-s samplerate (default: 2000000 Hz)]\n"
-		"\t[-R gain reduction (default: 50)]\n"
-        "\t[-l RSP LNA (default: 0, disabled)]\n"
-        "\t[-b Bandwidth in kHz (default: 1536)]\n"
-        "\t[-i IF bandwidth in kHz (default: 0)]\n"
-        "\t[-p ADC set point in dBfs (default: -30)]\n"
-        "\t[-n Broadcast Notch enable* (default: 0, disabled)]\n"
-        "\t[-r Refclk output enable* (default: 0, disabled)]\n"
-        "\t[-t Bias-T enable* (default: 0, disabled)]\n"
-        "\t[-a Antenna select* (0/1/2, default: 0, Port A)]\n"
-        "\t[-o PPM offset (default 0.0)]\n"
-        "\t[-A IF AGC enable (default: 1, enabled)]\n"
-        "\t[-x Output bitresolution (8/16, default: 16)]\n"
-        "\t[-v Verbose output (debug) enable (default: 0, disabled)]\n\n"
-		"\tfilename (a '-' dumps samples to stdout)\n\n"
-        "\tNote: options with * are only availale for the RSP2\n\n");
-	exit(1);
+    fprintf(stderr,
+            "play_sdr, an I/Q recorder for SDRplay RSP receivers\n\n"
+                    "Usage:\t[-f frequency_to_tune_to [Hz]\n"
+                    "\t[-d RSP device to use (default: 1, first found)]\n"
+                    "\t[-s samplerate (default: 2000000 Hz)]\n"
+                    "\t[-R gain reduction (default: 50)]\n"
+                    "\t[-l RSP LNA (default: 0, disabled)]\n"
+                    "\t[-b Bandwidth in kHz (default: 1536)]\n"
+                    "\t[-i IF bandwidth in kHz (default: 0)]\n"
+                    "\t[-p ADC set point in dBfs (default: -30)]\n"
+                    "\t[-n Broadcast Notch enable* (default: 0, disabled)]\n"
+                    "\t[-r Refclk output enable* (default: 0, disabled)]\n"
+                    "\t[-t Bias-T enable* (default: 0, disabled)]\n"
+                    "\t[-a Antenna select* (0/1/2, default: 0, Port A)]\n"
+                    "\t[-o PPM offset (default 0.0)]\n"
+                    "\t[-A IF AGC enable (default: 1, enabled)]\n"
+                    "\t[-x Output bitresolution (8/16, default: 16)]\n"
+                    "\t[-v Verbose output (debug) enable (default: 0, disabled)]\n\n"
+                    "\tfilename (a '-' dumps samples to stdout)\n\n"
+                    "\tNote: options with * are only availale for the RSP2\n\n");
+    exit(1);
 }
 
 #ifdef _WIN32
@@ -120,9 +120,9 @@ sighandler(int signum)
 #else
 static void sighandler(int signum)
 {
-	fprintf(stderr, "Signal caught, exiting!\n");
-	do_exit = 1;
-	mir_sdr_Uninit();
+    fprintf(stderr, "Signal caught, exiting!\n");
+    do_exit = 1;
+    mir_sdr_Uninit();
 }
 #endif
 
@@ -132,8 +132,8 @@ void gainCallback(unsigned int gRdB, unsigned int lnaGRdB, void *cbContext)
 }
 
 void streamCallback(short *xi, short *xq, unsigned int firstSampleNum,
-    int grChanged, int rfChanged, int fsChanged, unsigned int numSamples,
-    unsigned int reset, void *cbContext)
+                    int grChanged, int rfChanged, int fsChanged, unsigned int numSamples,
+                    unsigned int reset, void *cbContext)
 {
     if (outputRes == 16) {
         buf16 = malloc(numSamples * 2 * sizeof(short));
@@ -210,14 +210,14 @@ bool check_res(int res) {
 int main(int argc, char **argv)
 {
 #ifndef _WIN32
-	struct sigaction sigact;
+    struct sigaction sigact;
 #endif
-	char *filename = NULL;
-	mir_sdr_ErrT r;
+    char *filename = NULL;
+    mir_sdr_ErrT r;
     int opt;
-	uint32_t frequency = 100000000;
-	uint32_t samp_rate = DEFAULT_SAMPLE_RATE;
-	uint32_t out_block_size = DEFAULT_BUF_LENGTH;
+    uint32_t frequency = 100000000;
+    uint32_t samp_rate = DEFAULT_SAMPLE_RATE;
+    uint32_t out_block_size = DEFAULT_BUF_LENGTH;
     int rspLNA = 0;
     int i;
     int bwkHz = 1536;
@@ -239,118 +239,118 @@ int main(int argc, char **argv)
     mir_sdr_RSPII_AntennaSelectT ant = mir_sdr_RSPII_ANTENNA_A;
     int agcControl = 1;
 
-	while ((opt = getopt(argc, argv, "a:A:b:d:f:i:l:n:o:p:r:R:s:t:v:x:")) != -1) {
-		switch (opt) {
-        case 'a':
-            antenna = atoi(optarg);
-            break;
-        case 'A':
-            agcControl = atoi(optarg);
-            break;
-        case 'b':
-            bwkHz = atoi(optarg);
-            if (!check_bw(bwkHz)) {
-                fprintf(stderr, "\nERROR: IF bandwidth (%d kHz) not valid.\n", bwkHz);
-                fprintf(stderr, "Valid values: 200, 300, 600, 1536, 5000, 6000, 7000, 8000\n\n");
+    while ((opt = getopt(argc, argv, "a:A:b:d:f:i:l:n:o:p:r:R:s:t:v:x:")) != -1) {
+        switch (opt) {
+            case 'a':
+                antenna = atoi(optarg);
+                break;
+            case 'A':
+                agcControl = atoi(optarg);
+                break;
+            case 'b':
+                bwkHz = atoi(optarg);
+                if (!check_bw(bwkHz)) {
+                    fprintf(stderr, "\nERROR: IF bandwidth (%d kHz) not valid.\n", bwkHz);
+                    fprintf(stderr, "Valid values: 200, 300, 600, 1536, 5000, 6000, 7000, 8000\n\n");
+                    usage();
+                }
+                break;
+            case 'd':
+                device = atoi(optarg) - 1;
+                break;
+            case 'f':
+                frequency = (uint32_t)atofs(optarg);
+                break;
+            case 'i':
+                ifkHz = atoi(optarg);
+                if (!check_if(ifkHz)) {
+                    fprintf(stderr, "\nERROR: IF frequency (%d kHz) not valid.\n", ifkHz);
+                    fprintf(stderr, "Valid values: 0, 450, 1620, 2048\n\n");
+                    usage();
+                }
+                break;
+            case 'l':
+                rspLNA = atoi(optarg);
+                break;
+            case 'n':
+                notchEnable = atoi(optarg);
+                break;
+            case 'o':
+                ppmOffset = atof(optarg);
+                break;
+            case 'p':
+                setPoint = atol(optarg);
+                break;
+            case 'r':
+                refClk = atoi(optarg);
+                break;
+            case 'R':
+                gainR = atoi(optarg);
+                break;
+            case 's':
+                samp_rate = (uint32_t)atofs(optarg);
+                break;
+            case 't':
+                biasT = atoi(optarg);
+                break;
+            case 'v':
+                verbose = atoi(optarg);
+                break;
+            case 'x':
+                outputRes = atoi(optarg);
+                if (!check_res(outputRes)) {
+                    fprintf(stderr, "\nERROR: Only 8 or 16 bit output supported.\n");
+                    usage();
+                }
+                break;
+            default:
                 usage();
-            }
-            break;
-        case 'd':
-            device = atoi(optarg) - 1;
-            break;
-		case 'f':
-			frequency = (uint32_t)atofs(optarg);
-			break;
-        case 'i':
-            ifkHz = atoi(optarg);
-            if (!check_if(ifkHz)) {
-                fprintf(stderr, "\nERROR: IF frequency (%d kHz) not valid.\n", ifkHz);
-                fprintf(stderr, "Valid values: 0, 450, 1620, 2048\n\n");
-                usage();
-            }
-            break;
-        case 'l':
-            rspLNA = atoi(optarg);
-            break;
-		case 'n':
-			notchEnable = atoi(optarg);
-			break;
-        case 'o':
-            ppmOffset = atof(optarg);
-            break;
-        case 'p':
-            setPoint = atol(optarg);
-            break;
-        case 'r':
-            refClk = atoi(optarg);
-            break;
-		case 'R':
-			gainR = atoi(optarg); 
-			break;
-		case 's':
-			samp_rate = (uint32_t)atofs(optarg);
-			break;
-        case 't':
-            biasT = atoi(optarg);
-            break;
-        case 'v':
-            verbose = atoi(optarg);
-            break;
-        case 'x':
-            outputRes = atoi(optarg);
-            if (!check_res(outputRes)) {
-                fprintf(stderr, "\nERROR: Only 8 or 16 bit output supported.\n");
-                usage();
-            }
-            break;
-		default:
-			usage();
-			break;
-		}
-	}
+                break;
+        }
+    }
 
-	if (argc <= optind) {
-		usage();
-	} else {
-		filename = argv[optind];
-	}
+    if (argc <= optind) {
+        usage();
+    } else {
+        filename = argv[optind];
+    }
 
-	if(out_block_size < MINIMAL_BUF_LENGTH ||
-	   out_block_size > MAXIMAL_BUF_LENGTH ){
-		fprintf(stderr,
-			"Output block size wrong value, falling back to default\n");
-		fprintf(stderr,
-			"Minimal length: %u\n", MINIMAL_BUF_LENGTH);
-		fprintf(stderr,
-			"Maximal length: %u\n", MAXIMAL_BUF_LENGTH);
-		out_block_size = DEFAULT_BUF_LENGTH;
-	}
+    if(out_block_size < MINIMAL_BUF_LENGTH ||
+       out_block_size > MAXIMAL_BUF_LENGTH ){
+        fprintf(stderr,
+                "Output block size wrong value, falling back to default\n");
+        fprintf(stderr,
+                "Minimal length: %u\n", MINIMAL_BUF_LENGTH);
+        fprintf(stderr,
+                "Maximal length: %u\n", MAXIMAL_BUF_LENGTH);
+        out_block_size = DEFAULT_BUF_LENGTH;
+    }
 
 
 #ifndef _WIN32
-	sigact.sa_handler = sighandler;
-	sigemptyset(&sigact.sa_mask);
-	sigact.sa_flags = 0;
-	sigaction(SIGINT, &sigact, NULL);
-	sigaction(SIGTERM, &sigact, NULL);
-	sigaction(SIGQUIT, &sigact, NULL);
-	sigaction(SIGPIPE, &sigact, NULL);
+    sigact.sa_handler = sighandler;
+    sigemptyset(&sigact.sa_mask);
+    sigact.sa_flags = 0;
+    sigaction(SIGINT, &sigact, NULL);
+    sigaction(SIGTERM, &sigact, NULL);
+    sigaction(SIGQUIT, &sigact, NULL);
+    sigaction(SIGPIPE, &sigact, NULL);
 #else
-	SetConsoleCtrlHandler( (PHANDLER_ROUTINE) sighandler, TRUE );
+    SetConsoleCtrlHandler( (PHANDLER_ROUTINE) sighandler, TRUE );
 #endif
 
-	if(strcmp(filename, "-") == 0) { /* Write samples to stdout */
-		file = stdout;
+    if(strcmp(filename, "-") == 0) { /* Write samples to stdout */
+        file = stdout;
 #ifdef _WIN32
-		_setmode(_fileno(stdin), _O_BINARY);
+        _setmode(_fileno(stdin), _O_BINARY);
 #endif
-	} else {
-		file = fopen(filename, "wb");
-		if (!file) {
-			fprintf(stderr, "Failed to open %s\n", filename);
-			goto out;
-		}
-	}
+    } else {
+        file = fopen(filename, "wb");
+        if (!file) {
+            fprintf(stderr, "Failed to open %s\n", filename);
+            goto out;
+        }
+    }
 
     if (verbose > 0) {
         mir_sdr_DebugEnable(1);
@@ -359,16 +359,18 @@ int main(int argc, char **argv)
     mir_sdr_GetDevices(&devices[0], &numDevs, 4);
 
     for(i = 0; i < numDevs; i++) {
-        if(devices[i].hwVer == 2 && devices[i].devAvail == 1) {
-            devAvail++;
-        }
-        else{ // devAvail not available on RSP hardware Version 1
+        if(devices[i].devAvail == 1) {
             devAvail++;
         }
     }
 
     if (devAvail == 0) {
         fprintf(stderr, "ERROR: No RSP devices available.\n");
+        exit(1);
+    }
+
+    if (devices[device].devAvail != 1) {
+        fprintf(stderr, "ERROR: RSP selected (%d) is not available.\n", (device + 1));
         exit(1);
     }
 
@@ -393,14 +395,14 @@ int main(int argc, char **argv)
     }
 
     r = mir_sdr_StreamInit(&gainR, (samp_rate/1e6), (frequency/1e6),
-        (mir_sdr_Bw_MHzT)bwkHz, (mir_sdr_If_kHzT)ifkHz, rspLNA, &gRdBsystem,
-        grMode, &samplesPerPacket, streamCallback, gainCallback, &cbContext);
+                           (mir_sdr_Bw_MHzT)bwkHz, (mir_sdr_If_kHzT)ifkHz, rspLNA, &gRdBsystem,
+                           grMode, &samplesPerPacket, streamCallback, gainCallback, &cbContext);
 
-	if (r != mir_sdr_Success) {
-		fprintf(stderr, "Failed to start SDRplay RSP device.\n");
+    if (r != mir_sdr_Success) {
+        fprintf(stderr, "Failed to start SDRplay RSP device.\n");
         fprintf(stderr, "Use -v 1 (for verbose mode) to see the issue.\n");
-		exit(1);
-	}
+        exit(1);
+    }
 
     mir_sdr_AgcControl(agcControl, setPoint, 0, 0, 0, 0, rspLNA);
 
@@ -424,31 +426,31 @@ int main(int argc, char **argv)
         }
     }
 
-	fprintf(stderr, "Writing samples...");
+    fprintf(stderr, "Writing samples...");
     if (verbose > 0) {
         fprintf(stderr, "\n");
     }
-	while (!do_exit) {
+    while (!do_exit) {
         if (verbose < 1) {
             fprintf(stderr,".");
         }
         sleep(1);
-	}
+    }
 
-	if (do_exit)
-		fprintf(stderr, "\nUser cancel, exiting...\n");
-	else
-		fprintf(stderr, "\nLibrary error %d, exiting...\n", r);
+    if (do_exit)
+        fprintf(stderr, "\nUser cancel, exiting...\n");
+    else
+        fprintf(stderr, "\nLibrary error %d, exiting...\n", r);
 
-	if (file != stdout)
-		fclose(file);
+    if (file != stdout)
+        fclose(file);
 
-	mir_sdr_StreamUninit();
+    mir_sdr_StreamUninit();
 
     mir_sdr_ReleaseDeviceIdx();
 
     if (outputRes == 16) {
-	    free (buf16);
+        free (buf16);
     } else {
         free (buf8);
     }


### PR DESCRIPTION
Since my RSP 1 doesn't have a devAvail information, the example code failed to start up with the RSP 1, since it does not find any RSP...

**RSP 2, worked:** 
`f102@f102subn [17:59:07] [~/wrk/github/sdrplay_/examples] [master *]
-> % ./play_sdr -f 4200000  -v 1 -
mir_sdr_usb_GetDevices Dev0:vid=1df7 pid=3010 rev=0207 serno=170101DF00 bus=001 port=002 devAvail=1`

**RSP 1, ended up in an early ERROR:** 
`f102@f102subn [17:59:11] [~/wrk/github/sdrplay_/examples] [master *]
-> % ./play_sdr -f 4200000  -v 1 -
fwDownload: FW image size = 6008
mir_sdr_usb_GetDevices Dev0:vid=1df7 pid=2500 rev=0206 serno=B0001P0002 bus=001 port=002 devAvail=0
ERROR: No RSP devices available.
`